### PR TITLE
SQS Publisher Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.ini
 *.zip
 __pycache__/
+virtualenv/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,74 @@
 # canary-lambda
 
-## Summary
+This function has two modes: direct query mode and SQS-triggered mode. For simplicity, this README has been divided into two independent sections.
+
+SQS-triggered mode is the newer mode that listens to an SQS queue for notifications about new files being uploaded. When a new SQS message appears in the queue, this function will be triggered and begin the validation routine. Following the validation, results are published to a separate SQS queue.
+
+Directy query mode is the older, soon-to-be-deprecated mode that queries S3 directly for files uploaded today. All files are validated at once and results are directly pushed to Slack. This mode is severely limited in throughput and for that reason is not favored.
+
+# Mode 1: SQS-Triggered Mode
+
+This canary function is an early warning system that reports corrupt data. It listens to an SQS queue for notifications about new files in Amazon Web Services (AWS) Simple Storage Service (S3), and then validate that it meets certain field constraints.
+
+It utilizes the [ODE schema validation library](https://github.com/usdot-jpo-ode/ode-output-validator-library) to detect records with missing fields, blank fields, fields that do not match an expected range or value, as well as higher-level validations such as ensuring serial fields are sequential and incremented without gaps.
+
+After the canary completes its validation, it publishes the results to an output SQS queue.
+
+### Requirements
+
+- [Python 3.7](https://www.python.org/downloads/)
+- [PIP3](https://pip.pypa.io/en/stable/installing/)
+- [AWS Lambda Access](https://aws.amazon.com/lambda/)
+- S3 folder for storing large SQS messages
+- SQS queue for filepath notifications (source queue)
+- SQS queue for results publishing (non-FIFO) queue for message publishing (sink queue)
+- [S3 IAM role with lenient permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html)
+  - `s3:*`
+- [SQS IAM role with lenient permissions](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonsqs.html)
+  - `sqs:*`
+
+### Deployment
+
+This function is deployed manually by uploading a ZIP file to Lambda.
+
+#### Part 1: Local packaging
+1. Clone the code
+```
+git clone https://github.com/usdot-its-jpo-data-portal/canary-lambda.git
+```
+2. Install dependencies and package the code using the package.sh script:
+```
+./package.sh
+```
+3. A zip file named `canary.zip` will be created.
+
+#### Part 2: Deployment to Lambda
+
+1. [Create a Lambda function](https://docs.aws.amazon.com/lambda/latest/dg/getting-started-create-function.html)
+  - Select **Python 3.7** as the runtime and **main.lambda_handler** as the handler.
+2. Upload the `canary.zip` file
+3. Set the Execution role to one that has the S3 and SES permissions listed in the **Requirements** section above.
+4. Recommended resource settings: **Memory (MB)** `512 MB` and **Timeout** `5 min 0 sec`.
+5. Set the environment variables.
+
+### Configuration
+
+These configuration properties are sourced from environment variables. To set them locally, run `export PROPERTY_NAME=Value`, or change them in the **Environment variables** section in the AWS Lambda console.
+
+| Property            | Type             | Default Value | Description                                                                                                             |
+| ------------------- | ---------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| VERBOSE_OUTPUT      | Boolean          | FALSE         | Increases logging verbosity. Useful for debugging.                                                                      |
+| SQS_PUBLISHER_MODE | Boolean          | TRUE (must be TRUE for this mode)         | Activates SQS publisher mode                                              |
+| SQS_RESULT_QUEUE     | Array of strings | n/a           | Name of SQS queue to which validation results are sent (not the URL, not the ARN, just the name)                                                      |
+| SQS_STORAGE_S3_BUCKET           | String           | n/a           | Name of the S3 storage bucket used in sending large SQS messages                                                                  |
+
+### Usage
+
+Run the function by setting up an SQS event trigger from your source queue.
+
+# Mode 2: Direct Query Mode
+
+### Summary
 
 This canary function is an early warning system that reports corrupt data. It is meant to run once a day on a schedule, sample Amazon Web Services (AWS) Simple Storage Service (S3) data uploaded that day, and then validate that it meets certain field constraints.
 
@@ -10,7 +78,7 @@ After the canary completes its execution, it sends a report to Slack.
 
 ![Canary Diagram](images/canary_figure.png "Canary Diagram")
 
-## Requirements
+### Requirements
 
 - [Python 3.7](https://www.python.org/downloads/)
 - [PIP](https://pip.pypa.io/en/stable/installing/)
@@ -20,7 +88,7 @@ After the canary completes its execution, it sends a report to Slack.
   - `s3:List*`
 - (Optional) Slack and Slack webhook
 
-## Deployment
+### Deployment
 
 This function is deployed manually by uploading a ZIP file to Lambda.
 
@@ -47,7 +115,7 @@ git clone https://github.com/usdot-its-jpo-data-portal/canary-lambda.git
 5. Set the environment variables.
 ![Environment Variables](images/figure3.png "Environment Variables")
 
-## Configuration
+### Configuration
 
 These configuration properties are sourced from environment variables. To set them locally, run `export PROPERTY_NAME=Value`, or change them in the **Environment variables** section in the AWS Lambda console.
 
@@ -63,15 +131,18 @@ These configuration properties are sourced from environment variables. To set th
 | SLACK_WEBHOOK       | String           | n/a           | **WARNING - SECRET!** Slack app integration webhook url to which reports are sent.                                      |
 | DAY_OFFSET          | Integer          | -1            | How many days after today should the timestamp be offset. Default to yesterday. Useful when working with CRON triggers. |
 
-## Usage
+### Usage
 
 Run the function on a schedule by [setting up a CRON-triggered CloudWatch event](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/RunLambdaSchedule.html). (Note that the Cloudformation template includes a once-a-day CloudWatch trigger event at 12:01AM UTC).
 
-## Testing
+# Testing
 
 Run a local test by running the function as a standard python3 script: `python main.py`.
 
-## Release Notes
+# Release Notes
+
+### Version 0.0.4
+- Added SQS publisher mode
 
 ### Version 0.0.3
 - Added error list to output

--- a/main.py
+++ b/main.py
@@ -3,45 +3,121 @@ from datetime import datetime, timedelta, timezone
 import json
 import logging
 import os
+import pickle
 import queue
+import uuid
 from decimal import Decimal
 from odevalidator import TestCase
 from slacker import SlackMessage
+from sqs_client import SQSClientExtended
 
-### Data source settings
-S3_BUCKET = os.environ.get('S3_BUCKET')
-DATA_PROVIDERS = os.environ.get('DATA_PROVIDERS').split(',')
-MESSAGE_TYPES = os.environ.get('MESSAGE_TYPES').split(',')
-
-### Alerting settings
-SEND_SLACK_MESSAGE = True if os.environ.get('SEND_SLACK_MESSAGE') == 'TRUE' else False
-SLACK_WEBHOOK = os.environ.get('SLACK_WEBHOOK')
-
-### Debugging settings
+# Logger settings
 VERBOSE_OUTPUT = True if os.environ.get('VERBOSE_OUTPUT') == 'TRUE' else False
-USE_STATIC_PREFIXES = True if os.environ.get('USE_STATIC_PREFIXES') == 'TRUE' else False
-STATIC_PREFIXES = os.environ.get('STATIC_PREFIXES').split(',')
-DAY_OFFSET = int(os.environ.get('DAY_OFFSET'))
 
-### Local testing settings
-LOCAL_TEST_FILE = "test/data.txt"
+### Set this variable to FALSE to deactivate (will switch to direct-query mode)
+SQS_PUBLISHER_MODE = False if os.environ.get('SQS_PUBLISHER_MODE') == 'FALSE' else True
+
+if SQS_PUBLISHER_MODE:
+    SQS_RESULT_QUEUE = os.environ.get('SQS_RESULT_QUEUE')
+    assert SQS_RESULT_QUEUE != None, "Failed to get SQS_RESULT_QUEUE from environment (required for SQS_PUBLISHER_MODE)"
+    SQS_STORAGE_S3_BUCKET = os.environ.get('SQS_STORAGE_S3_BUCKET')
+    assert SQS_STORAGE_S3_BUCKET != None, "Failed to get SQS_STORAGE_S3_BUCKET from environment (required for SQS_PUBLISHER_MODE)"
+
+else:
+    ### Data source settings
+    S3_BUCKET = os.environ.get('S3_BUCKET')
+    DATA_PROVIDERS = os.environ.get('DATA_PROVIDERS').split(',')
+    MESSAGE_TYPES = os.environ.get('MESSAGE_TYPES').split(',')
+
+    ### Alerting settings
+    SEND_SLACK_MESSAGE = True if os.environ.get('SEND_SLACK_MESSAGE') == 'TRUE' else False
+    SLACK_WEBHOOK = os.environ.get('SLACK_WEBHOOK')
+
+    ### Debugging settings
+    USE_STATIC_PREFIXES = True if os.environ.get('USE_STATIC_PREFIXES') == 'TRUE' else False
+    STATIC_PREFIXES = os.environ.get('STATIC_PREFIXES').split(',')
+    DAY_OFFSET = int(os.environ.get('DAY_OFFSET'))
+
+    ### Local testing settings
+    LOCAL_TEST_FILE = "test/data.txt"
+
+# Setup logger
+root = logging.getLogger()
+if root.handlers: # Remove default AWS Lambda logging configuration
+    for handler in root.handlers:
+        root.removeHandler(handler)
+logger = logging.getLogger('canary')
+logging.basicConfig(format='%(levelname)s %(message)s')
+if VERBOSE_OUTPUT:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
-    validate(local_test=False, context=context)
+    if SQS_PUBLISHER_MODE:
+        sqs_validate(event=event, context=context)
+    else:
+        validate(local_test=False, context=context)
+
+def sqs_validate(event, context):
+
+    sqs_extended = SQSClientExtended.SQSClientExtended(s3_bucket_name=SQS_STORAGE_S3_BUCKET)
+
+    logger.debug("Received SQS event: %s" % event)
+
+    s3_client = boto3.client('s3')
+    sqs_client = boto3.client('sqs')
+    results_queue = boto3.resource('sqs').get_queue_by_name(QueueName=SQS_RESULT_QUEUE)
+    test_case = TestCase()
+
+    logger.info("SQS event received. Number of records in SQS event: %d" % len(event['Records']))
+
+    for sqs_message in event['Records']:
+        # Validate records from file
+        sqs_message_body = json.loads(sqs_message['body'])
+        bucket = sqs_message_body['bucket']
+        file_key = sqs_message_body['key']
+        logger.info("Processing data file with path: %s/%s" % (bucket, file_key))
+        msg_queue = queue.Queue()
+        record_list = extract_records_from_file(s3_client, file_key, bucket, False)
+        logger.debug("Found %d records in file." % len(record_list))
+        for record in record_list:
+            msg_queue.put(str(record, 'utf-8'))
+        validation_results = test_case.validate_queue(msg_queue)
+        jsonified_validation_results = []
+        for result in validation_results:
+            jsonified_validation_results.append(result.to_json())
+        # serialized_results = json.dumps(jsonified_validation_results)
+
+        # Send off results
+        msg = {'key': "%s/%s" % (bucket, file_key), 'results': jsonified_validation_results}
+        msg_group_id = str(uuid.uuid4())
+        logger.debug("Publishing results to queue with MessageGroupId = %s." % msg_group_id)
+        # logger.debug("Message size: %d" % len(jsonified_validation_results))
+
+        logger.debug("Querying for URL of result queue...")
+        result_queue_url = sqs_client.get_queue_url(QueueName=SQS_RESULT_QUEUE)['QueueUrl']
+        logger.debug("Found results queue URL from query: %s" % result_queue_url)
+
+        logger.debug("Publishing results to SQS queue...")
+        sqs_extended.send_message(queue_url=result_queue_url, message=json.dumps(msg), message_attributes={})
+        logger.info("Validation results successfully published to results SQS queue.")
+
+        # Delete file message from queue
+        receipt_handle = sqs_message['receiptHandle']
+        queue_name = sqs_message['eventSourceARN'].split(':')[5]
+        logger.debug("Querying for queue_url for message deletion. MessageReceiptHandle: %s, QueueName: %s" % (receipt_handle, queue_name))
+        queue_url = sqs_client.get_queue_url(QueueName=queue_name)['QueueUrl']
+        logger.debug("Received queue_url from query request: %s" % (queue_url))
+        logger.debug("Sending deletion request for ReceiptHandle %s to QueueUrl %s" % (receipt_handle, queue_url))
+        sqs_client.delete_message(
+            QueueUrl=queue_url,
+            ReceiptHandle=receipt_handle
+        )
+        logger.info("Message successfully deleted from ingest SQS queue.")
 
 def validate(local_test, context):
     function_start_time = datetime.now()
-    # Setup logger
-    root = logging.getLogger()
-    if root.handlers: # Remove default AWS Lambda logging configuration
-        for handler in root.handlers:
-            root.removeHandler(handler)
-    logger = logging.getLogger('canary')
-    logging.basicConfig(format='%(levelname)s %(message)s')
-    if VERBOSE_OUTPUT:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
 
     # Setup S3 query params
     prefix_strings = []
@@ -73,7 +149,7 @@ def validate(local_test, context):
     for filename in s3_file_list:
         logger.info("============================================================================")
         logger.info("Analyzing file '%s'" % filename)
-        record_list = extract_records_from_file(s3_client, filename, local_test)
+        record_list = extract_records_from_file(s3_client, filename, S3_BUCKET, local_test)
         for record in record_list:
             records_analyzed += 1
             if local_test:
@@ -132,7 +208,7 @@ def validate(local_test, context):
     return
 
 ### Returns a list of records from a given file
-def extract_records_from_file(s3_client, filename, local_test):
+def extract_records_from_file(s3_client, filename, s3_bucket, local_test):
     if local_test:
         print("(Local test) Loading test data from local file.")
         test_records = []
@@ -142,7 +218,7 @@ def extract_records_from_file(s3_client, filename, local_test):
         return test_records
     else:
         s3_file = s3_client.get_object(
-            Bucket=S3_BUCKET,
+            Bucket=s3_bucket,
             Key=filename,
         )
         return s3_file['Body'].read().splitlines()
@@ -178,4 +254,27 @@ def list_s3_objects(s3_client, prefix_string, continuation_token=None):
 
 if __name__ == '__main__':
     print("(Local test) Running local test...")
-    validate(local_test=True, context=None)
+    if SQS_PUBLISHER_MODE:
+        test_event = {
+          "Records": [
+            {
+              "messageId": "19dd0b57-b21e-4ac1-bd88-01bbb068cb78",
+              "receiptHandle": "MessageReceiptHandle",
+              "body": "{\"bucket\": \"test-usdot-its-cvpilot-public-data\", \"key\": \"wydot/BSM/2018/12/14/23/test-usdot-its-cvpilot-bsm-public-0-2018-12-14-23-00-00-2b7bc4ce-b93c-40a6-bdcb-7a1b02e1d9da\"}",
+              "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1523232000000",
+                "SenderId": "123456789012",
+                "ApproximateFirstReceiveTimestamp": "1523232000001"
+              },
+              "messageAttributes": {},
+              "md5OfBody": "7b270e59b47ff90a553787216d55d91d",
+              "eventSource": "aws:sqs",
+              "eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:MyQueue",
+              "awsRegion": "us-east-1"
+            }
+          ]
+        }
+        sqs_validate(event=test_event, context=None)
+    else:
+        validate(local_test=True, context=None)

--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 pip install -r requirements.txt --upgrade --target .
-zip -r canary.zip main.py slacker.py odevalidator*/
+ls odevalidator
+zip -r canary.zip main.py slacker.py odevalidator*/ sqs_client/
 rm -rf odevalidator*/
 echo "Created package in canary.zip"


### PR DESCRIPTION
Adds the new SQS publisher mode, does not remove old-style code so as to allow for backwards-compatibility.

I've named the old mode "direct query mode" and the new one "SQS publisher mode", the switch between the two is toggled with an environment variable.

