### PR TITLE
Skip validation if data is not from WYDOT

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -86,7 +86,10 @@ def sqs_validate(event, context):
         logger.debug("Found %d records in file." % len(record_list))
         for record in record_list:
             msg_queue.put(str(record, 'utf-8'))
-        validation_results = test_case.validate_queue(msg_queue)
+        if pilot_name == 'wydot':
+            validation_results = test_case.validate_queue(msg_queue)
+        else:
+            validation_results = test_case.validate_queue(msg_queue, skip=True)
         jsonified_validation_results = []
         for result in validation_results:
             jsonified_validation_results.append(result.to_json())


### PR DESCRIPTION
Skipping validation if data is not from WYDOT.
This is so that we can still get the count reports for both WYDOT and THEA without having to wait for the validators to be configured for THEA data.